### PR TITLE
I9 remove dup

### DIFF
--- a/TicTacToeRuby.Core/GamePlay/computer_actions.rb
+++ b/TicTacToeRuby.Core/GamePlay/computer_actions.rb
@@ -32,31 +32,68 @@ class ComputerActions
       next_moves.each do |move|
 	      tile = board[move]
         board[move] = player_symbol
-      	if player_symbol == current_player
+
+        #Refactored:
+        if player_symbol == current_player
           i_won = GameOverValidator.win_for_player?(player_symbol, board)
-      	  if i_won 
-            # An early win has an advantage:
-      	    current_score = BoardScoreValidator.evaluate_score_of_board(board, current_player, other_player) * depth
-      	  else
-      	    current_score = get_best_move(board, other_player, depth - 1, best_max_value, best_min_value).score
-          end
+          opposing_symbol = other_player
+        else
+          he_won = GameOverValidator.win_for_player?(player_symbol, board)
+          opposing_symbol = current_player
+        end
+    	  if i_won || he_won
+          # An early win or block has an advantage:
+    	    current_score = BoardScoreValidator.evaluate_score_of_board(board, current_player, other_player) * depth
+    	  else
+    	    current_score = get_best_move(board, opposing_symbol, depth - 1, best_max_value, best_min_value).score
+        end
+        if player_symbol == current_player
           if current_score > best_max_value
             best_max_value = current_score
             best_move = move
       	  end
-      	else
-    	    he_won = GameOverValidator.win_for_player?(player_symbol, board)
-    	    if he_won
-            # A block is an advantage:
-    	      current_score = BoardScoreValidator.evaluate_score_of_board(board, current_player, other_player) * depth
-    	    else
-            current_score = get_best_move(board, current_player, depth - 1, best_max_value, best_min_value).score
-    	    end
-    	    if current_score < best_min_value
-    	      best_min_value = current_score
-    	      best_move = move
-    	    end
+        else #player_symbol = other_player:
+          if current_score < best_min_value
+            best_min_value = current_score
+            best_move = move
+          end
       	end
+         
+    	    
+    	    
+    	    
+      	
+
+
+
+        #Original:
+        # if player_symbol == current_player
+        #   i_won = GameOverValidator.win_for_player?(player_symbol, board)
+        #   if i_won 
+        #     # An early win has an advantage:
+        #     current_score = BoardScoreValidator.evaluate_score_of_board(board, current_player, other_player) * depth
+        #   else
+        #     current_score = get_best_move(board, other_player, depth - 1, best_max_value, best_min_value).score
+        #   end
+        #   if current_score > best_max_value
+        #     best_max_value = current_score
+        #     best_move = move
+        #   end
+        # else #player_symbol = other_player
+        #   he_won = GameOverValidator.win_for_player?(player_symbol, board)
+        #   if he_won
+        #     # A block is an advantage:
+        #     current_score = BoardScoreValidator.evaluate_score_of_board(board, current_player, other_player) * depth
+        #   else
+        #     current_score = get_best_move(board, current_player, depth - 1, best_max_value, best_min_value).score
+        #   end
+        #   if current_score < best_min_value
+        #     best_min_value = current_score
+        #     best_move = move
+        #   end
+        # end
+
+
     	  #Reset the board tile:
         board[move] = tile
     	  #Stop traversing more nodes in this branch:

--- a/TicTacToeRuby.Core/GamePlay/computer_actions.rb
+++ b/TicTacToeRuby.Core/GamePlay/computer_actions.rb
@@ -34,14 +34,13 @@ class ComputerActions
         board[move] = player_symbol
 
         #Refactored:
-        if player_symbol == current_player
-          i_won = GameOverValidator.win_for_player?(player_symbol, board)
+        win_exists = GameOverValidator.win_for_player?(player_symbol, board)
+        if player_symbol == current_player 
           opposing_symbol = other_player
         else
-          he_won = GameOverValidator.win_for_player?(player_symbol, board)
           opposing_symbol = current_player
         end
-    	  if i_won || he_won
+    	  if win_exists
           # An early win or block has an advantage:
     	    current_score = BoardScoreValidator.evaluate_score_of_board(board, current_player, other_player) * depth
     	  else

--- a/TicTacToeRuby.Core/GamePlay/computer_actions.rb
+++ b/TicTacToeRuby.Core/GamePlay/computer_actions.rb
@@ -32,8 +32,6 @@ class ComputerActions
       next_moves.each do |move|
 	      tile = board[move]
         board[move] = player_symbol
-
-        #Refactored:
         win_exists = GameOverValidator.win_for_player?(player_symbol, board)
         if player_symbol == current_player 
           opposing_symbol = other_player
@@ -51,48 +49,12 @@ class ComputerActions
             best_max_value = current_score
             best_move = move
       	  end
-        else #player_symbol = other_player:
+        else
           if current_score < best_min_value
             best_min_value = current_score
             best_move = move
           end
       	end
-         
-    	    
-    	    
-    	    
-      	
-
-
-
-        #Original:
-        # if player_symbol == current_player
-        #   i_won = GameOverValidator.win_for_player?(player_symbol, board)
-        #   if i_won 
-        #     # An early win has an advantage:
-        #     current_score = BoardScoreValidator.evaluate_score_of_board(board, current_player, other_player) * depth
-        #   else
-        #     current_score = get_best_move(board, other_player, depth - 1, best_max_value, best_min_value).score
-        #   end
-        #   if current_score > best_max_value
-        #     best_max_value = current_score
-        #     best_move = move
-        #   end
-        # else #player_symbol = other_player
-        #   he_won = GameOverValidator.win_for_player?(player_symbol, board)
-        #   if he_won
-        #     # A block is an advantage:
-        #     current_score = BoardScoreValidator.evaluate_score_of_board(board, current_player, other_player) * depth
-        #   else
-        #     current_score = get_best_move(board, current_player, depth - 1, best_max_value, best_min_value).score
-        #   end
-        #   if current_score < best_min_value
-        #     best_min_value = current_score
-        #     best_move = move
-        #   end
-        # end
-
-
     	  #Reset the board tile:
         board[move] = tile
     	  #Stop traversing more nodes in this branch:


### PR DESCRIPTION
Added resolution to issue #9 for removing duplication of code from get_best_move method. 
I added a generic variable to identify the "opposing symbol" and injected that into the method call in the else statement. This made those lines of code truly duplicate to facilitate splicing them out. 
I split the duplicating code lines from the if statement and called the if statement again once the app had to compare the current_score with either the best max or min value. 